### PR TITLE
Add redis (ElastiCache) for notifications

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -258,7 +258,7 @@ resource "aws_ecs_task_definition" "histomics_task" {
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 4096
-  memory                   = 8192
+  memory                   = 16384
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
   container_definitions = jsonencode(
     [
@@ -269,12 +269,12 @@ resource "aws_ecs_task_definition" "histomics_task" {
           "gunicorn",
           "girder.wsgi:app",
           "--bind=0.0.0.0:8080",
-          "--workers=5",
+          "--workers=4",
           "--preload",
           "--timeout=7200"
         ],
         cpu       = 4096
-        memory    = 8192
+        memory    = 16384
         essential = true
         portMappings = [
           {
@@ -306,6 +306,10 @@ resource "aws_ecs_task_definition" "histomics_task" {
           {
             name  = "GIRDER_STATIC_REST_ONLY" # don't dynamically generate slicer_cli_web endpoints
             value = "true"
+          },
+          {
+            name  = "GIRDER_NOTIFICATION_REDIS_URL"
+            value = "redis://default:${random_password.redis_password.result}@${aws_elasticache_replication_group.redis.primary_endpoint_address}:6379"
           }
         ],
         mountPoints = [

--- a/terraform/redis.tf
+++ b/terraform/redis.tf
@@ -1,0 +1,54 @@
+resource "random_password" "redis_password" {
+  length  = 20
+  special = false
+}
+
+resource "aws_elasticache_user" "histomics" {
+  user_id       = "histomics"
+  user_name     = "default"
+  access_string = "on ~* +@all"
+  engine        = "REDIS"
+  passwords     = [random_password.redis_password.result]
+}
+
+resource "aws_elasticache_user_group" "histomics" {
+  user_group_id   = "histomics"
+  engine          = "REDIS"
+  user_ids        = [aws_elasticache_user.histomics.user_id]
+}
+
+resource "aws_security_group" "redis_sg" {
+  name        = "redis-sg"
+  description = "Allow Redis access"
+  vpc_id      = aws_default_vpc.default.id
+
+  ingress {
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = [aws_default_vpc.default.cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id          = "histomics"
+  description                   = "Histomics Redis"
+  engine                        = "redis"
+  engine_version                = "7.0"
+  node_type                     = "cache.t3.micro"
+  num_cache_clusters            = 1
+  automatic_failover_enabled    = false
+
+  user_group_ids                = [aws_elasticache_user_group.histomics.user_group_id]
+  security_group_ids            = [aws_security_group.redis_sg.id]
+
+  transit_encryption_enabled    = true
+  at_rest_encryption_enabled    = true
+}


### PR DESCRIPTION
This doesn't actually deploy the new Girder notification system, but it puts the infrastructure in place for it.